### PR TITLE
DOC-1865-Update-pyTG_V1.5ToDocs

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -42,7 +42,7 @@ content:
     - url: https://github.com/tigergraph/mlworkbench-docs.git
       branches: [1.0, 1.1, 1.2, 1.3, 1.4]
     - url: https://github.com/tigergraph/pytigergraph-docs
-      branches: ["v1.0", "v1.1", "v1.2","v1.3","v1.4"]
+      branches: ["v1.0", "v1.1", "v1.2","v1.3","v1.4","v1.5"]
     - url: https://github.com/tigergraph/insights-docs
       branches: [3.7, 3.8, 3.9]
 ui:

--- a/home/modules/ROOT/pages/index.adoc
+++ b/home/modules/ROOT/pages/index.adoc
@@ -6,7 +6,7 @@ Here you can find the reference materials, guides, and examples to develop your 
 
 [NOTE]
 ====
-* xref:1.5@pytigergraph:release-notes:index.adoc[pyTigerGraph 1.5] was released on Sept. [day], 2023.
+* xref:1.5@pytigergraph:release-notes:index.adoc[pyTigerGraph 1.5] was released on Sept. 25th, 2023.
 * xref:tigergraph-server:release-notes:index.adoc[TigerGraph 3.9.2] was released on June 29, 2023.
 * xref:1.4@pytigergraph:release-notes:index.adoc[pyTigerGraph 1.4] and
 xref:1.4@ml-workbench:faq:release-notes.adoc[ML Workbench 1.4] were released on May 17, 2023.

--- a/home/modules/ROOT/pages/index.adoc
+++ b/home/modules/ROOT/pages/index.adoc
@@ -6,6 +6,7 @@ Here you can find the reference materials, guides, and examples to develop your 
 
 [NOTE]
 ====
+* xref:1.5@pytigergraph:release-notes:index.adoc[pyTigerGraph 1.5] was released on Sept. [day], 2023.
 * xref:tigergraph-server:release-notes:index.adoc[TigerGraph 3.9.2] was released on June 29, 2023.
 * xref:1.4@pytigergraph:release-notes:index.adoc[pyTigerGraph 1.4] and
 xref:1.4@ml-workbench:faq:release-notes.adoc[ML Workbench 1.4] were released on May 17, 2023.


### PR DESCRIPTION
This pull request sets up the documentation update for the pyTigerGraph v1.5 update.

**Date for release was decided for Monday, Sept, 25th 2023